### PR TITLE
[#98] [backend] enhancements for stress testing

### DIFF
--- a/LingvoFriend Test Plan.jmx
+++ b/LingvoFriend Test Plan.jmx
@@ -1,0 +1,473 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="LingvoFriend Test Plan">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="mongoHost" elementType="Argument">
+            <stringProp name="Argument.name">mongoHost</stringProp>
+            <stringProp name="Argument.value">lingvofriend.fun</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="mongoPort" elementType="Argument">
+            <stringProp name="Argument.name">mongoPort</stringProp>
+            <stringProp name="Argument.value">27017</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="databaseName" elementType="Argument">
+            <stringProp name="Argument.name">databaseName</stringProp>
+            <stringProp name="Argument.value">lfDB</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="collectionName" elementType="Argument">
+            <stringProp name="Argument.name">collectionName</stringProp>
+            <stringProp name="Argument.value">Users</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group">
+        <intProp name="ThreadGroup.num_threads">300</intProp>
+        <intProp name="ThreadGroup.ramp_time">0</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/auth/register">
+          <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/api/auth/register</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+  &quot;username&quot;: &quot;${__RandomString(10,0123456789,)}&quot;,&#xd;
+  &quot;password&quot;: &quot;${__RandomString(10,0123456789,)}&quot;&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/questionnaire/saveGoals">
+          <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/api/questionnaire/saveGoals</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+    &quot;goals&quot;: [&#xd;
+        &quot;Путешествие&quot;,&#xd;
+        &quot;Общение с людьми&quot;,&#xd;
+        &quot;Полезное занятие&quot;,&#xd;
+        &quot;Просто так&quot;,&#xd;
+        &quot;Саморазвитие&quot;,&#xd;
+        &quot;Карьерный рост&quot;&#xd;
+    ]&#xd;
+}&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/questionnaire/saveInterests">
+          <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/api/questionnaire/saveInterests</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+    &quot;interests&quot;: [&#xd;
+        &quot;Музыка&quot;,&#xd;
+        &quot;Путешествия&quot;,&#xd;
+        &quot;Искусство&quot;,&#xd;
+        &quot;Спорт&quot;,&#xd;
+        &quot;Игры&quot;,&#xd;
+        &quot;Кулинария&quot;,&#xd;
+        &quot;Технологии&quot;,&#xd;
+        &quot;Космос&quot;&#xd;
+    ]&#xd;
+}&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">10</stringProp>
+        </LoopController>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/jwt/validate">
+            <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.path">/api/jwt/validate</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/history">
+            <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.path">/api/history</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/saveUnknownWord">
+            <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.path">/api/saveUnknownWord</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <stringProp name="HTTPSampler.method">POST</stringProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">{&#xd;
+  &quot;word&quot;: &quot;${__RandomString(10,0123456789,)}&quot;&#xd;
+}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/api/user/getProfileData">
+            <stringProp name="HTTPSampler.domain">lingvofriend.fun</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.path">/api/user/getProfileData</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+        </hashTree>
+        <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager">
+          <collectionProp name="CookieManager.cookies"/>
+          <boolProp name="CookieManager.clearEachIteration">false</boolProp>
+          <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
+        </CookieManager>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Content-Type</stringProp>
+              <stringProp name="Header.value">application/json</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+      </hashTree>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <BackendListener guiclass="BackendListenerGui" testclass="BackendListener" testname="Backend Listener" enabled="true">
+        <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments">
+          <collectionProp name="Arguments.arguments">
+            <elementProp name="graphiteMetricsSender" elementType="Argument">
+              <stringProp name="Argument.name">graphiteMetricsSender</stringProp>
+              <stringProp name="Argument.value">org.apache.jmeter.visualizers.backend.graphite.TextGraphiteMetricsSender</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="graphiteHost" elementType="Argument">
+              <stringProp name="Argument.name">graphiteHost</stringProp>
+              <stringProp name="Argument.value"></stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="graphitePort" elementType="Argument">
+              <stringProp name="Argument.name">graphitePort</stringProp>
+              <stringProp name="Argument.value">2003</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="rootMetricsPrefix" elementType="Argument">
+              <stringProp name="Argument.name">rootMetricsPrefix</stringProp>
+              <stringProp name="Argument.value">jmeter.</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="summaryOnly" elementType="Argument">
+              <stringProp name="Argument.name">summaryOnly</stringProp>
+              <stringProp name="Argument.value">true</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="samplersList" elementType="Argument">
+              <stringProp name="Argument.name">samplersList</stringProp>
+              <stringProp name="Argument.value"></stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="percentiles" elementType="Argument">
+              <stringProp name="Argument.name">percentiles</stringProp>
+              <stringProp name="Argument.value">90;95;99</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+          </collectionProp>
+        </elementProp>
+        <stringProp name="classname">org.apache.jmeter.visualizers.backend.graphite.GraphiteBackendListenerClient</stringProp>
+      </BackendListener>
+      <hashTree/>
+      <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="StatGraphVisualizer" testclass="ResultCollector" testname="Aggregate Graph" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group" enabled="true">
+        <intProp name="ThreadGroup.num_threads">1</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </SetupThreadGroup>
+      <hashTree>
+        <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="BeanShell Sampler" enabled="true">
+          <stringProp name="BeanShellSampler.query">import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.JMeterGUIComponent;
+import org.apache.jmeter.gui.tree.JMeterTreeNode;
+import org.apache.jmeter.samplers.Clearable;
+
+log.info(&quot;Clearing All ...&quot;);
+
+guiPackage = GuiPackage.getInstance();
+
+guiPackage.getMainFrame().clearData();
+for (JMeterTreeNode node : guiPackage.getTreeModel().getNodesOfType(Clearable.class)) {
+    JMeterGUIComponent guiComp = guiPackage.getGui(node.getTestElement());
+    if (guiComp instanceof Clearable){
+        Clearable item = (Clearable) guiComp;
+        try {
+            item.clearData();
+        } catch (Exception ex) {
+            log.error(&quot;Can&apos;t clear: &quot;+node+&quot; &quot;+guiComp, ex);
+        }
+    }
+}</stringProp>
+        </BeanShellSampler>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/backend/src/main/java/com/lingvoFriend/backend/Controllers/JwtController.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Controllers/JwtController.java
@@ -4,6 +4,7 @@ import com.lingvoFriend.backend.Services.AuthService.AuthService;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.AllArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -19,12 +20,6 @@ public class JwtController {
     @GetMapping("/validate")
     public ResponseEntity<String> validateToken(@CookieValue("__Host-auth-token") String token) {
         return authService.validateToken(token);
-    }
-
-    @GetMapping("/username")
-    public ResponseEntity<String> getUsernameFromToken(
-            @CookieValue("__Host-auth-token") String token) {
-        return authService.getUsernameFromToken(token);
     }
 
     @GetMapping("/clear")

--- a/backend/src/main/java/com/lingvoFriend/backend/Controllers/QuestionnaireController.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Controllers/QuestionnaireController.java
@@ -1,12 +1,13 @@
 package com.lingvoFriend.backend.Controllers;
 
 import com.lingvoFriend.backend.Repositories.UserRepository;
+import com.lingvoFriend.backend.Security.JwtGenerator;
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.QuestionnaireService.QuestionnaireQuestion;
 import com.lingvoFriend.backend.Services.QuestionnaireService.QuestionnaireService;
 import com.lingvoFriend.backend.Services.QuestionnaireService.dto.QuestionnaireGoalsDto;
-
 import com.lingvoFriend.backend.Services.QuestionnaireService.dto.QuestionnaireInterestsDto;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -24,6 +25,7 @@ public class QuestionnaireController {
     @Autowired private QuestionnaireService questionnaireService;
     @Autowired private UserRepository userRepository;
     @Autowired private MongoTemplate mongoTemplate;
+    @Autowired private JwtGenerator jwtGenerator;
 
     @PostMapping("/start")
     public ResponseEntity<QuestionnaireQuestion> startQuestionnaire(@RequestParam String userId) {
@@ -46,8 +48,9 @@ public class QuestionnaireController {
 
     @PostMapping("/saveGoals")
     public ResponseEntity<String> saveGoals(
+            @CookieValue("__Host-auth-token") String token,
             @RequestBody QuestionnaireGoalsDto questionnaireGoalsDto) {
-        String username = questionnaireGoalsDto.getUsername();
+        String username = jwtGenerator.getUsernameFromToken(token);
         List<String> goals = questionnaireGoalsDto.getGoals();
 
         UserModel user =
@@ -66,8 +69,9 @@ public class QuestionnaireController {
 
     @PostMapping("/saveInterests")
     public ResponseEntity<String> saveInterests(
+            @CookieValue("__Host-auth-token") String token,
             @RequestBody QuestionnaireInterestsDto questionnaireInterestsDto) {
-        String username = questionnaireInterestsDto.getUsername();
+        String username = jwtGenerator.getUsernameFromToken(token);
         List<String> interests = questionnaireInterestsDto.getInterests();
 
         UserModel user =

--- a/backend/src/main/java/com/lingvoFriend/backend/Controllers/UserController.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Controllers/UserController.java
@@ -21,12 +21,18 @@ class UserController {
     @GetMapping("/getProfileData")
     public ResponseEntity<UserProfileDto> getUserData(
             @CookieValue("__Host-auth-token") String token) {
-        String username = jwtGenerator.getUsernameFromToken(token);
-        List<String> goals = userService.getGoals(username);
-        List<String> interests = userService.getInterests(username);
-        String cefrLevel = userService.getCefrLevel(username);
+        try {
+            String username = jwtGenerator.getUsernameFromToken(token);
+            List<String> goals = userService.getGoals(username);
+            List<String> interests = userService.getInterests(username);
+            String cefrLevel = userService.getCefrLevel(username);
 
-        return ResponseEntity.ok(new UserProfileDto(username, goals, interests, cefrLevel));
+            return ResponseEntity.ok(new UserProfileDto(username, goals, interests, cefrLevel));
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
     }
 
     @GetMapping("/username")

--- a/backend/src/main/java/com/lingvoFriend/backend/Controllers/UserController.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Controllers/UserController.java
@@ -1,7 +1,8 @@
 package com.lingvoFriend.backend.Controllers;
 
 import com.lingvoFriend.backend.Security.JwtGenerator;
-import com.lingvoFriend.backend.Services.ChatService.UserService;
+import com.lingvoFriend.backend.Services.UserService.UserService;
+import com.lingvoFriend.backend.Services.UserService.dto.UserProfileDto;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -12,10 +13,21 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/profile")
-class UserProfileController {
+@RequestMapping("/api/user")
+class UserController {
     @Autowired private UserService userService;
     @Autowired private JwtGenerator jwtGenerator;
+
+    @GetMapping("/getProfileData")
+    public ResponseEntity<UserProfileDto> getUserData(
+            @CookieValue("__Host-auth-token") String token) {
+        String username = jwtGenerator.getUsernameFromToken(token);
+        List<String> goals = userService.getGoals(username);
+        List<String> interests = userService.getInterests(username);
+        String cefrLevel = userService.getCefrLevel(username);
+
+        return ResponseEntity.ok(new UserProfileDto(username, goals, interests, cefrLevel));
+    }
 
     @GetMapping("/username")
     public ResponseEntity<String> getUsernameInfo(@CookieValue("__Host-auth-token") String token) {
@@ -61,7 +73,7 @@ class UserProfileController {
     public ResponseEntity<String> getLevelInfo(@CookieValue("__Host-auth-token") String token) {
         try {
             String username = jwtGenerator.getUsernameFromToken(token);
-            String level = userService.getLevel(username);
+            String level = userService.getCefrLevel(username);
             if (level == null || level.isEmpty()) {
                 return ResponseEntity.ok("unknown");
             }

--- a/backend/src/main/java/com/lingvoFriend/backend/Controllers/UserProfileController.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Controllers/UserProfileController.java
@@ -1,31 +1,39 @@
 package com.lingvoFriend.backend.Controllers;
 
-import java.util.List;
+import com.lingvoFriend.backend.Security.JwtGenerator;
+import com.lingvoFriend.backend.Services.ChatService.UserService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import com.lingvoFriend.backend.Services.ChatService.UserService;
-
-import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/profile")
 class UserProfileController {
+    @Autowired private UserService userService;
+    @Autowired private JwtGenerator jwtGenerator;
 
-    @Autowired
-    private UserService userService;
-
-    @GetMapping("/goals/{username}")
-    public ResponseEntity<List<String>> getGoalsInfo(
-        HttpServletRequest request, @PathVariable String username) {
+    @GetMapping("/username")
+    public ResponseEntity<String> getUsernameInfo(@CookieValue("__Host-auth-token") String token) {
         try {
+            String username = jwtGenerator.getUsernameFromToken(token);
+            return ResponseEntity.ok(username);
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    @GetMapping("/goals")
+    public ResponseEntity<List<String>> getGoalsInfo(
+            @CookieValue("__Host-auth-token") String token) {
+        try {
+            String username = jwtGenerator.getUsernameFromToken(token);
             List<String> goals = userService.getGoals(username);
             return ResponseEntity.ok(goals);
         } catch (BadCredentialsException e) {
@@ -35,10 +43,11 @@ class UserProfileController {
         }
     }
 
-    @GetMapping("/interests/{username}")
+    @GetMapping("/interests")
     public ResponseEntity<List<String>> getInterestsInfo(
-        HttpServletRequest request, @PathVariable String username) {
+            @CookieValue("__Host-auth-token") String token) {
         try {
+            String username = jwtGenerator.getUsernameFromToken(token);
             List<String> interests = userService.getInterests(username);
             return ResponseEntity.ok(interests);
         } catch (BadCredentialsException e) {
@@ -48,13 +57,13 @@ class UserProfileController {
         }
     }
 
-    @GetMapping("/level/{username}")
-    public ResponseEntity<String> getLevelInfo(
-        HttpServletRequest request, @PathVariable String username) {
+    @GetMapping("/level")
+    public ResponseEntity<String> getLevelInfo(@CookieValue("__Host-auth-token") String token) {
         try {
+            String username = jwtGenerator.getUsernameFromToken(token);
             String level = userService.getLevel(username);
             if (level == null || level.isEmpty()) {
-                return ResponseEntity.ok("unknown"); 
+                return ResponseEntity.ok("unknown");
             }
             return ResponseEntity.ok(level);
         } catch (BadCredentialsException e) {
@@ -63,5 +72,4 @@ class UserProfileController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
         }
     }
-
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/AuthService/AuthService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/AuthService/AuthService.java
@@ -83,8 +83,7 @@ public class AuthService {
         }
     }
 
-    public ResponseEntity<String> getUsernameFromToken(String token) {
-        String username = jwtGenerator.getUsernameFromToken(token);
-        return ResponseEntity.ok().body(username);
+    public String getUsernameFromToken(String token) {
+        return jwtGenerator.getUsernameFromToken(token);
     }
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/ChatService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/ChatService.java
@@ -4,6 +4,7 @@ import com.lingvoFriend.backend.Security.JwtGenerator;
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.dto.UserMessageDto;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
+import com.lingvoFriend.backend.Services.UserService.UserService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/ChatService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/ChatService.java
@@ -1,5 +1,6 @@
 package com.lingvoFriend.backend.Services.ChatService;
 
+import com.lingvoFriend.backend.Security.JwtGenerator;
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.dto.UserMessageDto;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
@@ -9,9 +10,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.time.Instant;
 
 @Service
 public class ChatService {
@@ -19,13 +20,15 @@ public class ChatService {
     @Autowired private LlmService llmService;
     @Autowired private LanguageLevelService languageLevelService;
     @Autowired private WordsReminderService wordsReminderService;
+    @Autowired private JwtGenerator jwtGenerator;
 
     private LlmReminderService llmReminderService;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Integer remainderFrequency = 25;
 
-    public String chat(UserMessageDto userMessageDto) {
-        UserModel user = userService.findOrThrow(userMessageDto.getUsername());
+    public String chat(String token, UserMessageDto userMessageDto) {
+        String username = jwtGenerator.getUsernameFromToken(token);
+        UserModel user = userService.findOrThrow(username);
         userService.addMessageToUser(user, userMessageDto.getMessage());
 
         if (userMessageDto.getMessage().isSystem()) return "successfully added system message";

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/LanguageLevelService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/LanguageLevelService.java
@@ -2,6 +2,8 @@ package com.lingvoFriend.backend.Services.ChatService;
 
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
+import com.lingvoFriend.backend.Services.UserService.UserService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/LanguageLevelService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/LanguageLevelService.java
@@ -3,12 +3,22 @@ package com.lingvoFriend.backend.Services.ChatService;
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
 
 @Service
 public class LanguageLevelService {
+    @Autowired private UserService userService;
+    @Autowired private LlmService llm;
+    @Autowired private MongoTemplate mongoTemplate;
+
+    private final Integer levelEvalQuestionsNumber = 5;
+
     public boolean isEvaluated(UserModel user) {
         Integer status = user.getLevelEvaluationQuestionsAsked();
         return status > levelEvalQuestionsNumber;
@@ -18,7 +28,8 @@ public class LanguageLevelService {
         Integer status = user.getLevelEvaluationQuestionsAsked();
         if (status.equals(0)) {
             startEvaluation(user);
-            String initialPrompt = "New user entered chat. Evaluate his level of English by asking questions. Now ask the first question.";
+            String initialPrompt =
+                    "New user entered chat. Evaluate his level of English by asking questions. Now ask the first question.";
             Message initMessage = new Message();
             initMessage.setRole("system");
             initMessage.setText(initialPrompt);
@@ -35,7 +46,8 @@ public class LanguageLevelService {
             return llm.generateLlmResponse(user);
         }
         if (status.equals(levelEvalQuestionsNumber)) {
-            String prompt = "User answered, now based on user's previous answers evaluate the user's level on the CEFR scale based on their answers. Just write A1, A2, B1, B2, C1, or C2 as an answer.";
+            String prompt =
+                    "User answered, now based on user's previous answers evaluate the user's level on the CEFR scale based on their answers. Just write A1, A2, B1, B2, C1, or C2 as an answer.";
             Message levelMessage = new Message();
             levelMessage.setRole("system");
             levelMessage.setText(prompt);
@@ -50,13 +62,18 @@ public class LanguageLevelService {
             String userGoals = userService.constructUserGoalsString(user);
             String userPreferences = userService.constructUserPreferencesString(user);
 
-            String topicPrompt = "Do not answer about CEFR level, it is no longer needed. " +
-                    "From now on just chat with the user in English, notice that you should not answer in any other language except the situations when user asks for it explicitly. " +
-                    "The user has the following goals: " + userGoals + ". " +
-                    "The user's preferred topics are: " + userPreferences + ". " +
-                    "Start the conversation by discussing one of these topics." +
-                    "Talk with user as if you were native British citizen";
-            
+            String topicPrompt =
+                    "Do not answer about CEFR level, it is no longer needed. "
+                            + "From now on just chat with the user in English, notice that you should not answer in any other language except the situations when user asks for it explicitly. "
+                            + "The user has the following goals: "
+                            + userGoals
+                            + ". "
+                            + "The user's preferred topics are: "
+                            + userPreferences
+                            + ". "
+                            + "Start the conversation by discussing one of these topics."
+                            + "Talk with user as if you were native British citizen";
+
             Message topicMsg = new Message();
             topicMsg.setRole("system");
             topicMsg.setText(topicPrompt);
@@ -64,24 +81,30 @@ public class LanguageLevelService {
 
             return llm.generateLlmResponse(user);
         }
-        throw new IllegalStateException("evaluate must not be called if user has already been evaluated");
+        throw new IllegalStateException(
+                "evaluate must not be called if user has already been evaluated");
     }
 
     private void questionsAskedPlusOne(UserModel user) {
-        user.setLevelEvaluationQuestionsAsked(user.getLevelEvaluationQuestionsAsked() + 1);
-        user.setCefrLevel(null);
-        userService.getUserRepository().save(user);
+        Query query = new Query(Criteria.where("_id").is(user.getId()));
+        Update update =
+                new Update()
+                        .set(
+                                "levelEvaluationQuestionsAsked",
+                                user.getLevelEvaluationQuestionsAsked() + 1);
+        mongoTemplate.updateFirst(query, update, UserModel.class);
     }
 
     private void startEvaluation(UserModel user) {
-        user.setLevelEvaluationQuestionsAsked(1);
-        user.setCefrLevel(null);
-        userService.getUserRepository().save(user);
+        Query query = new Query(Criteria.where("_id").is(user.getId()));
+        Update update = new Update().set("levelEvaluationQuestionsAsked", 1);
+        mongoTemplate.updateFirst(query, update, UserModel.class);
     }
 
     private void setCefrLevel(UserModel user, String level) {
-        user.setCefrLevel(level);
-        userService.getUserRepository().save(user);
+        Query query = new Query(Criteria.where("_id").is(user.getId()));
+        Update update = new Update().set("cefrLevel", level);
+        mongoTemplate.updateFirst(query, update, UserModel.class);
     }
 
     private String extractCEFRLevel(String text) {
@@ -95,11 +118,4 @@ public class LanguageLevelService {
         int index = random.nextInt(cefrLevels.length);
         return cefrLevels[index];
     }
-
-    private final Integer levelEvalQuestionsNumber = 5;
-
-    @Autowired
-    private UserService userService;
-    @Autowired
-    private LlmService llm;
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/LlmReminderService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/LlmReminderService.java
@@ -2,6 +2,8 @@ package com.lingvoFriend.backend.Services.ChatService;
 
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
+import com.lingvoFriend.backend.Services.UserService.UserService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/UserService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/UserService.java
@@ -8,6 +8,10 @@ import com.lingvoFriend.backend.Services.ChatService.models.Word;
 import lombok.Getter;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +23,7 @@ import java.util.StringJoiner;
 public class UserService {
 
     @Getter @Autowired private UserRepository userRepository;
+    @Autowired private MongoTemplate mongoTemplate;
 
     public UserModel findOrThrow(String username) {
         return userRepository
@@ -34,7 +39,10 @@ public class UserService {
     public void addMessageToUser(UserModel user, Message message) {
         if (message != null) {
             user.getMessages().add(message);
-            userRepository.save(user);
+
+            Query query = new Query(Criteria.where("_id").is(user.getId()));
+            Update update = new Update().set("messages", user.getMessages());
+            mongoTemplate.updateFirst(query, update, UserModel.class);
         }
     }
 
@@ -47,7 +55,9 @@ public class UserService {
             user.getUnknownWords().remove(user.getUnknownWords().last());
         }
 
-        userRepository.save(user);
+        Query query = new Query(Criteria.where("_id").is(user.getId()));
+        Update update = new Update().set("unknownWords", user.getUnknownWords());
+        mongoTemplate.updateFirst(query, update, UserModel.class);
     }
 
     public String constructUserGoalsString(UserModel user) {

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/WordsReminderService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/WordsReminderService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -25,6 +26,7 @@ public class WordsReminderService {
         // it'll be shown not earlier than 30 minutes from now as the first reminderStep
         unknownWord.setTime(unknownWord.getTime().plus(Duration.ofMinutes(30)));
         unknownWord.setStep(1);
+
         userService.addUnknownWordToUser(user, unknownWord);
     }
 
@@ -64,22 +66,22 @@ public class WordsReminderService {
 
         switch (currentStep) {
             case 1:
-                word.setTime(word.getTime().plus(periodList.get(0)));
+                word.setTime(Instant.now().plus(periodList.get(0)));
                 break;
             case 2:
-                word.setTime(word.getTime().plus(periodList.get(1)));
+                word.setTime(Instant.now().plus(periodList.get(1)));
                 break;
             case 3:
-                word.setTime(word.getTime().plus(periodList.get(2)));
+                word.setTime(Instant.now().plus(periodList.get(2)));
                 break;
             case 4:
-                word.setTime(word.getTime().plus(periodList.get(3)));
+                word.setTime(Instant.now().plus(periodList.get(3)));
                 break;
             case 5:
-                word.setTime(word.getTime().plus(periodList.get(4)));
+                word.setTime(Instant.now().plus(periodList.get(4)));
                 break;
             case 6:
-                word.setTime(word.getTime().plus(periodList.get(5)));
+                word.setTime(Instant.now().plus(periodList.get(5)));
                 break;
         }
 

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/WordsReminderService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/WordsReminderService.java
@@ -1,5 +1,6 @@
 package com.lingvoFriend.backend.Services.ChatService;
 
+import com.lingvoFriend.backend.Security.JwtGenerator;
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.dto.WordsReminderDto;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
@@ -15,11 +16,14 @@ import java.util.List;
 @Service
 public class WordsReminderService {
     @Autowired private UserService userService;
+    @Autowired private JwtGenerator jwtGenerator;
+
     public static final int storageCapacity = 100;
     public static final int reminderSteps = 7;
 
-    public void saveUnknownWord(WordsReminderDto wordsReminderDto) {
-        UserModel user = userService.findOrThrow(wordsReminderDto.getUsername());
+    public void saveUnknownWord(String token, WordsReminderDto wordsReminderDto) {
+        String username = jwtGenerator.getUsernameFromToken(token);
+        UserModel user = userService.findOrThrow(username);
         Word unknownWord = new Word(wordsReminderDto.getWord());
 
         // when user clicks on unknownWord for the first time

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/WordsReminderService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/WordsReminderService.java
@@ -5,6 +5,7 @@ import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
 import com.lingvoFriend.backend.Services.ChatService.dto.WordsReminderDto;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
 import com.lingvoFriend.backend.Services.ChatService.models.Word;
+import com.lingvoFriend.backend.Services.UserService.UserService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/dto/UserMessageDto.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/dto/UserMessageDto.java
@@ -6,6 +6,5 @@ import lombok.Data;
 
 @Data
 public class UserMessageDto {
-    private String username;
     private Message message;
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/dto/WordsReminderDto.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/ChatService/dto/WordsReminderDto.java
@@ -4,6 +4,5 @@ import lombok.Data;
 
 @Data
 public class WordsReminderDto {
-    private String username;
     private String word;
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/QuestionnaireService/dto/QuestionnaireGoalsDto.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/QuestionnaireService/dto/QuestionnaireGoalsDto.java
@@ -6,6 +6,5 @@ import java.util.List;
 
 @Data
 public class QuestionnaireGoalsDto {
-    private String username;
     private List<String> goals;
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/QuestionnaireService/dto/QuestionnaireInterestsDto.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/QuestionnaireService/dto/QuestionnaireInterestsDto.java
@@ -6,6 +6,5 @@ import java.util.List;
 
 @Data
 public class QuestionnaireInterestsDto {
-    private String username;
     private List<String> interests;
 }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/UserService/UserService.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/UserService/UserService.java
@@ -1,7 +1,8 @@
-package com.lingvoFriend.backend.Services.ChatService;
+package com.lingvoFriend.backend.Services.UserService;
 
 import com.lingvoFriend.backend.Repositories.UserRepository;
 import com.lingvoFriend.backend.Services.AuthService.models.UserModel;
+import com.lingvoFriend.backend.Services.ChatService.WordsReminderService;
 import com.lingvoFriend.backend.Services.ChatService.models.Message;
 import com.lingvoFriend.backend.Services.ChatService.models.Word;
 
@@ -88,7 +89,7 @@ public class UserService {
         return user.getInterests();
     }
 
-    public String getLevel(String username) {
+    public String getCefrLevel(String username) {
         UserModel user = findOrThrow(username);
         return user.getCefrLevel();
     }

--- a/backend/src/main/java/com/lingvoFriend/backend/Services/UserService/dto/UserProfileDto.java
+++ b/backend/src/main/java/com/lingvoFriend/backend/Services/UserService/dto/UserProfileDto.java
@@ -1,0 +1,15 @@
+package com.lingvoFriend.backend.Services.UserService.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class UserProfileDto {
+    private String username;
+    private List<String> goals;
+    private List<String> interests;
+    private String cefrLevel;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,13 +11,10 @@ import Welcome from "./components/pages/welcome/Welcome";
 import RegisterForm from "./components/authForm/RegisterForm";
 import Chat from "./components/pages/chat/Chat";
 import Store from "./components/pages/store/Store";
-import { useState } from "react";
 import Questionnaire from "./components/pages/questionnaire/Questionnaire";
 import useAuth from "./components/authForm/useAuth";
 
 function App() {
-    const [username, setUsername] = useState(null);
-
     const PrivateRoute = ({ children }) => {
         const isAuthenticated = useAuth();
 
@@ -49,10 +46,7 @@ function App() {
                         </PublicRoute>
                     }
                 />
-                <Route
-                    path="/login"
-                    element={<LoginForm setUsername={setUsername} />}
-                />
+                <Route path="/login" element={<LoginForm />} />
                 <Route path="/register" element={<RegisterForm />} />
 
                 <Route
@@ -83,7 +77,7 @@ function App() {
                     path="/chat"
                     element={
                         <PrivateRoute>
-                            <Chat username={username} />
+                            <Chat />
                         </PrivateRoute>
                     }
                 />

--- a/frontend/src/components/authForm/LoginForm.jsx
+++ b/frontend/src/components/authForm/LoginForm.jsx
@@ -3,7 +3,7 @@ import { FaLock, FaUser } from "react-icons/fa";
 import { useNavigate, Link } from "react-router-dom";
 import "./authForm.css";
 
-const LoginForm = ({ setUsername }) => {
+const LoginForm = () => {
     const [username, setInputUsername] = useState("");
     const [password, setPassword] = useState("");
     const navigate = useNavigate();

--- a/frontend/src/components/pages/chat/Chat.jsx
+++ b/frontend/src/components/pages/chat/Chat.jsx
@@ -6,7 +6,7 @@ import BottomBar from "../../bottomBar/BottomBar";
 import ReactTooltip from "react-tooltip";
 import "./chat.css";
 
-const DialogWord = ({ segment, index, username }) => {
+const DialogWord = ({ segment, index }) => {
     const [translation, setTranslation] = useState(null);
     const [isLoadingWord, setIsLoadingWord] = useState(null);
     const tooltipId = `tooltip-${index}-${segment}`;
@@ -36,7 +36,6 @@ const DialogWord = ({ segment, index, username }) => {
             );
 
             const requestBody = {
-                username: username,
                 word: word,
             };
 
@@ -88,7 +87,6 @@ const DialogWord = ({ segment, index, username }) => {
 
 const Chat = () => {
     const [messages, setMessages] = useState([]);
-    const [username, setUsername] = useState(null);
     const [input, setInput] = useState("");
     const chatEndRef = useRef(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -96,37 +94,11 @@ const Chat = () => {
     const serverUrl = process.env.REACT_APP_SERVER_URL || "";
 
     useEffect(() => {
-        const fetchUsername = async () => {
-            try {
-                const response = await axios.get(
-                    `${serverUrl}/api/jwt/username`,
-                    {
-                        withCredentials: true,
-                    }
-                );
-
-                setUsername(response.data);
-            } catch (error) {
-                console.error("Ошибка при получении username:", error);
-            }
-        };
-
-        fetchUsername();
-    }, [serverUrl]);
-
-    useEffect(() => {
         const fetchChatHistory = async () => {
-            if (!username) {
-                return;
-            }
-
             try {
-                const response = await axios.get(
-                    `${serverUrl}/api/history/${username}`,
-                    {
-                        withCredentials: true,
-                    }
-                );
+                const response = await axios.get(`${serverUrl}/api/history`, {
+                    withCredentials: true,
+                });
                 const chatHistory = response.data;
                 if (chatHistory.length === 0) {
                     const welcomeMessage = {
@@ -142,10 +114,8 @@ const Chat = () => {
             }
         };
 
-        if (username) {
-            fetchChatHistory();
-        }
-    }, [username, serverUrl]);
+        fetchChatHistory();
+    }, [serverUrl]);
 
     useEffect(() => {
         chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -163,7 +133,6 @@ const Chat = () => {
 
         try {
             const requestBody = {
-                username: username,
                 message: {
                     role: "user",
                     text: input,
@@ -238,13 +207,7 @@ const Chat = () => {
         const messageText = extractText(text) || "";
         const wordsAndPunctuations = messageText.split(/(\s+|[.,!?;:()])/);
         return wordsAndPunctuations.map((segment, index) => {
-            return (
-                <DialogWord
-                    segment={segment}
-                    index={index}
-                    username={username}
-                />
-            );
+            return <DialogWord segment={segment} index={index} />;
         });
     };
 

--- a/frontend/src/components/pages/profile/Profile.jsx
+++ b/frontend/src/components/pages/profile/Profile.jsx
@@ -16,32 +16,31 @@ const Profile = () => {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const [
-                    usernameResponse,
-                    goalsResponse,
-                    interestsResponse,
-                    levelResponse,
-                ] = await Promise.all([
-                    axios.get(`${serverUrl}/api/profile/username`, {
+                const response = await axios.get(
+                    `${serverUrl}/api/user/getProfileData`,
+                    {
                         withCredentials: true,
-                    }),
-                    axios.get(`${serverUrl}/api/profile/goals`, {
-                        withCredentials: true,
-                    }),
-                    axios.get(`${serverUrl}/api/profile/interests`, {
-                        withCredentials: true,
-                    }),
-                    axios.get(`${serverUrl}/api/profile/level`, {
-                        withCredentials: true,
-                    }),
-                ]);
+                    }
+                );
 
-                setUsername(usernameResponse.data);
-                setGoals(goalsResponse.data);
-                setInterests(interestsResponse.data);
-
-                const level = levelResponse.data;
-                setLevel(level === "unknown" ? "Неизвестен" : level);
+                setUsername(
+                    response.data.username === null
+                        ? "Неизвестен"
+                        : response.data.username
+                );
+                setGoals(
+                    response.data.goals === null ? [] : response.data.goals
+                );
+                setInterests(
+                    response.data.interests === null
+                        ? []
+                        : response.data.interests
+                );
+                setLevel(
+                    response.data.cefrLevel === null
+                        ? "Неизвестен"
+                        : response.data.cefrLevel
+                );
             } catch (err) {
                 console.error("Error fetching data:", err);
                 setError("Failed to load data. Please try again later.");

--- a/frontend/src/components/pages/profile/Profile.jsx
+++ b/frontend/src/components/pages/profile/Profile.jsx
@@ -1,50 +1,45 @@
 import React, { useState, useEffect } from "react";
 import BottomBar from "../../bottomBar/BottomBar";
-import "./profile.css"
+import "./profile.css";
 import axios from "axios";
 
 const Profile = () => {
+    const [username, setUsername] = useState([]);
     const [goals, setGoals] = useState([]);
     const [interests, setInterests] = useState([]);
     const [level, setLevel] = useState([]);
-    const [username, setUsername] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
 
     const serverUrl = process.env.REACT_APP_SERVER_URL || "";
 
     useEffect(() => {
-        const fetchUsername = async () => {
-            try {
-                const response = await axios.get(
-                    `${serverUrl}/api/jwt/username`,
-                    {
-                        withCredentials: true,
-                    }   
-                );
-                setUsername(response.data);
-            } catch (err) {
-                console.error("Error fetching username:", err);
-                setError("Failed to retrieve username.");
-            }
-        };
-
-        fetchUsername();
-    }, [serverUrl]);
-
-    useEffect(() => {
         const fetchData = async () => {
-            if (!username) return;
-    
             try {
-                const [goalsResponse, interestsResponse, levelResponse] = await Promise.all([
-                    axios.get(`${serverUrl}/api/profile/goals/${username}`, { withCredentials: true }),
-                    axios.get(`${serverUrl}/api/profile/interests/${username}`, { withCredentials: true }),
-                    axios.get(`${serverUrl}/api/profile/level/${username}`, { withCredentials: true }),
+                const [
+                    usernameResponse,
+                    goalsResponse,
+                    interestsResponse,
+                    levelResponse,
+                ] = await Promise.all([
+                    axios.get(`${serverUrl}/api/profile/username`, {
+                        withCredentials: true,
+                    }),
+                    axios.get(`${serverUrl}/api/profile/goals`, {
+                        withCredentials: true,
+                    }),
+                    axios.get(`${serverUrl}/api/profile/interests`, {
+                        withCredentials: true,
+                    }),
+                    axios.get(`${serverUrl}/api/profile/level`, {
+                        withCredentials: true,
+                    }),
                 ]);
-    
+
+                setUsername(usernameResponse.data);
                 setGoals(goalsResponse.data);
                 setInterests(interestsResponse.data);
+
                 const level = levelResponse.data;
                 setLevel(level === "unknown" ? "Неизвестен" : level);
             } catch (err) {
@@ -54,10 +49,9 @@ const Profile = () => {
                 setIsLoading(false);
             }
         };
-    
+
         fetchData();
-    }, [username, serverUrl]);
-    
+    }, [serverUrl]);
 
     if (isLoading) {
         return <div className="profile-container">Loading...</div>;
@@ -70,14 +64,10 @@ const Profile = () => {
         <div>
             <div className="profile-container">
                 <div className="profile-header">Мой профиль</div>
-                <div>
-                    Имя: {username}
-                </div>
-                <div>
-                    Уровень владения языком: {level}
-                </div>        
+                <div>Имя: {username}</div>
+                <div>Уровень владения языком: {level}</div>
                 <div>Цели изучения языка</div>
-                    <div className="profile-list">
+                <div className="profile-list">
                     {goals.length === 0 ? (
                         <p>No goals available.</p>
                     ) : (
@@ -87,10 +77,10 @@ const Profile = () => {
                             ))}
                         </ul>
                     )}
-                    <div/>
+                    <div />
                 </div>
-                    <div>Мои интересы</div>
-                    <div className="profile-list">
+                <div>Мои интересы</div>
+                <div className="profile-list">
                     {interests.length === 0 ? (
                         <p>No interests available.</p>
                     ) : (
@@ -100,7 +90,7 @@ const Profile = () => {
                             ))}
                         </ul>
                     )}
-                    </div>
+                </div>
             </div>
             <BottomBar />
         </div>

--- a/frontend/src/components/pages/questionnaire/pages/goals/Goals.jsx
+++ b/frontend/src/components/pages/questionnaire/pages/goals/Goals.jsx
@@ -33,17 +33,7 @@ const Goals = ({ progress, onNextStep }) => {
         const serverUrl = process.env.REACT_APP_SERVER_URL || "";
 
         try {
-            const usernameResponse = await axios.get(
-                `${serverUrl}/api/jwt/username`,
-                {
-                    withCredentials: true,
-                }
-            );
-
-            const username = usernameResponse.data;
-
             const requestBody = {
-                username: username,
                 goals: selectedGoals,
             };
 

--- a/frontend/src/components/pages/questionnaire/pages/interests/Interests.jsx
+++ b/frontend/src/components/pages/questionnaire/pages/interests/Interests.jsx
@@ -37,17 +37,7 @@ const Interests = ({ username, progress, onNextStep, onSubmit }) => {
         const serverUrl = process.env.REACT_APP_SERVER_URL || "";
 
         try {
-            const usernameResponse = await axios.get(
-                `${serverUrl}/api/jwt/username`,
-                {
-                    withCredentials: true,
-                }
-            );
-
-            const username = usernameResponse.data;
-
             const requestBody = {
-                username: username,
                 interests: selectedInterests,
             };
 


### PR DESCRIPTION
- now we update specific fields in the user document instead of overwriting the entire document when adding or modifying data in the database, providing greater efficiency
- removed the 'api/history/{username}' endpoint in ChatController (now it's just 'api/history') and the '/api/jwt/username' endpoint in JwtController, along with the 'username' field in several DTOs. This change eliminates the need for an additional frontend request to fetch the username, as it can now be retrieved directly from the JWT token on backend
- endpoints in UserController that were providing data for the Profile page have been consolidated into a single endpoint
- а Stress Test Plan has been implemented in JMeter

Closes #98 